### PR TITLE
fix: patch SO table pagination key uniqueness

### DIFF
--- a/app/src/pages/stakingOptions/stakingOptions.tsx
+++ b/app/src/pages/stakingOptions/stakingOptions.tsx
@@ -148,7 +148,7 @@ export const StakingOptions = (props: { network: string }) => {
           }
 
           const soParams = createSoParams(
-            soName,
+            `${soName}-${soMint.toString()}`,
             soName,
             new PublicKey(authority),
             new Date(Number(optionExpiration) * 1_000).toDateString().split(' ').slice(1).join(' '),


### PR DESCRIPTION
## Description
antd's Table component relies on a unique string key to ensure proper sorting and pagination. Since page was feeding rows with non-unique keys, those would get included if at least one of them made it into the page slice. This PR fixes that.