### PR TITLE
feat: make data table full width for desktop

### DIFF
--- a/app/src/components/Layout/Layout.module.scss
+++ b/app/src/components/Layout/Layout.module.scss
@@ -18,17 +18,17 @@
   @include tablet {
     margin-bottom: 16px;
     padding: 0 16px;
-    max-width: calc(736px + 32px);
+    width: calc(736px + 32px);
   }
 
   @include laptop {
     margin-bottom: 16px;
     padding: 0 24px;
-    max-width: calc(944px + 48px);
+    width: calc(944px + 48px);
   }
 
   @include desktop {
     margin-bottom: 44px;
-    max-width: calc(1360px + 48px);
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Description
PR makes data table full width for desktop. Although issue specifies making SO table full width, all tabs share the same table container hence the patch applies to every tab not just SO. If this is undesirable, please lmk and I'll condition styling strictly for SO tab.