### PR TITLE
192-fix-inverted-strike

### DIFF
--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -575,10 +575,12 @@ export function decimalsBaseSPL(token: string) {
   }
 }
 
-export function dollarize(amount: number, locale = 'en-US'): string {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency: 'USD', maximumSignificantDigits: 4 }).format(
-    amount
-  );
+export function dollarize(amount: number, locale = 'en-US', sigFigs = 4): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: 'USD',
+    maximumSignificantDigits: sigFigs,
+  }).format(amount);
 }
 
 export function isUpsidePool(quoteMint: PublicKey) {
@@ -680,4 +682,11 @@ export function getSoStrike(
   const strikeQuoteAtomsPerAtom = strikeQuoteAtomsPerLot / lotSize;
   const strikeTokensPerToken = strikeQuoteAtomsPerAtom * 10 ** (baseDecimals - quoteDecimals);
   return strikeTokensPerToken;
+}
+
+export function isUSDCQuotePair(baseMint: PublicKey, quoteMint: PublicKey): boolean {
+  const isUSDCPair =
+    Config.usdcMintPk().toString() === baseMint.toString() || Config.usdcMintPk().toString() === quoteMint.toString();
+
+  return isUSDCPair;
 }


### PR DESCRIPTION
Added USDC pair check + Inversion of quote

Changed `dollarize` function params to include `sigFig` amount

Changed `strikeQuoteAtomsPerBaseToken` to string for dollarized conversion

![image](https://github.com/Dual-Finance/status/assets/33764516/386bb552-0317-42ed-adcd-15178d0741d9)
