### PR TITLE
style: add colored table sorters

### DIFF
--- a/app/src/components/UI/DualfiTable/DualfiTable.module.scss
+++ b/app/src/components/UI/DualfiTable/DualfiTable.module.scss
@@ -135,10 +135,9 @@
       align-items: center;
     }
 
-    .ant-table-column-sorter-inner .anticon-caret-down,
-    .ant-table-column-sorter-inner .anticon-caret-up {
-      font-size: 8px;
-      color: $table-thead-color;
+    .ant-table-column-sorter-up.active,
+    .ant-table-column-sorter-down.active {
+      color: $dual-green;
     }
 
     // pagination and footer

--- a/app/src/styles/_variables.scss
+++ b/app/src/styles/_variables.scss
@@ -4,6 +4,7 @@
 // color
 $black: #000000;
 $white: #ffffff;
+$dual-green: #53c8a1;
 
 // main-colors
 $text-color-primary: #000000;


### PR DESCRIPTION
## Description
PR adds colored sorters in tables for current sort direction, making viewing experience a bit nicer.

### Screenshots
<img width="165" alt="image" src="https://github.com/Dual-Finance/status/assets/12281609/b2ef76b4-38e6-4c1d-b566-42ecbbab31ca">
<img width="165" alt="image" src="https://github.com/Dual-Finance/status/assets/12281609/f9106a8a-88f1-48d8-875e-77565c9a8924">

